### PR TITLE
Replace use of Parser::$mStripState, deprecated in 1.35

### DIFF
--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -93,7 +93,7 @@ function createPageIfNotExisting( array $rawParams ) {
 	}
 
 	// Get the raw text of $newPageContent as it was before stripping <nowiki>:
-	$newPageContent = $parser->mStripState->unstripNoWiki( $newPageContent );
+	$newPageContent = $parser->getStripState()->unstripNoWiki( $newPageContent );
 
 	// Store data in the parser output for later use:
 	$createPageData = $parser->getOutput()->getExtensionData( 'createPage' );


### PR DESCRIPTION
The replacement, Parser::getStripState(), was added to MediaWiki in
1.34.

Bug: T275160