### PR TITLE
Update for usage in mediawiki 1.39

### DIFF
--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -142,7 +142,7 @@ function createPageIfNotExisting( array $rawParams ) {
 	}
 
 	// Get the raw text of $newPageContent as it was before stripping <nowiki>:
-	$newPageContent = $parser->mStripState->unstripNoWiki( $newPageContent );
+	$newPageContent = $parser->getStripState()->unstripNoWiki( $newPageContent );
 
 	// Store data in the parser output for later use:
 	$createPageData = $parser->getOutput()->getExtensionData( 'createPage' );

--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -22,10 +22,8 @@
  * @file
  */
 
-print "Hello World :)";
 if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
-	print "Hello World :(";
 }
 
 /**

--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -29,6 +29,7 @@ function logthis($asd){
             $myfile = fopen($egAutoCreatePageLogfile,"a");
             fwrite($myfile,$asd);
             fwrite($myfile,"\n");
+	    fclose($myfile);
             return true;
         } catch (Exception $e) {
             return false;

--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -22,6 +22,7 @@
  * @file
  */
 
+print "Hello World :)";
 if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
 }

--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -22,8 +22,17 @@
  * @file
  */
 
+
+function logthis($asd){ 
+    $myfile = fopen("/tmp/debug_mw.txt","a");
+    fwrite($myfile,$asd);
+    fwrite($myfile,"\n");
+   
+
+}
+
 if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'Not an entry point.' );
+    die( 'Not an entry point.' );
 }
 
 /**
@@ -65,9 +74,11 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
  * in the default text parameter to insert verbatim wiki text.
  */
 function createPageIfNotExisting( array $rawParams ) {
-	global $egAutoCreatePageMaxRecursion, $egAutoCreatePageIgnoreEmptyTitle, $egAutoCreatePageNamespaces;
+    logthis("createPageIfNotExisting is run!");
+    global $egAutoCreatePageMaxRecursion, $egAutoCreatePageIgnoreEmptyTitle, $egAutoCreatePageNamespaces;
+    if ( $egAutoCreatePageMaxRecursion <= 0 ) {
 
-	if ( $egAutoCreatePageMaxRecursion <= 0 ) {
+        logthis("Recursion Level Exceeded.");
 		return 'Error: Recursion level for auto-created pages exeeded.'; //TODO i18n
 	}
 
@@ -75,21 +86,29 @@ function createPageIfNotExisting( array $rawParams ) {
 		$parser = $rawParams[0];
 		$newPageTitleText = $rawParams[1];
 		$newPageContent = $rawParams[2];
-	} else {
+    } else {
+
+        logthis("Missing parameters!");
 		throw new MWException( 'Hook invoked with missing parameters.' );
 	}
 
 	if ( empty( $newPageTitleText ) ) {
-		if ( $egAutoCreatePageIgnoreEmptyTitle === false ) {
+        if ( $egAutoCreatePageIgnoreEmptyTitle === false ) {
+            
+            logthis("Valid title missing!");
 			return 'Error: this function must be given a valid title text for the page to be created.'; //TODO i18n
-		} else {
+        } else {
+
+            logthis("?0");
 			return '';
 		}
 	}
 
 	// Create pages only if the page calling the parser function is within defined namespaces
 	if ( !in_array( $parser->getTitle()->getNamespace(), $egAutoCreatePageNamespaces ) ) {
-		return '';
+        
+        logthis("?1");
+        return '';
 	}
 
 	// Get the raw text of $newPageContent as it was before stripping <nowiki>:
@@ -103,6 +122,7 @@ function createPageIfNotExisting( array $rawParams ) {
 	$createPageData[$newPageTitleText] = $newPageContent;
 	$parser->getOutput()->setExtensionData( 'createPage', $createPageData );
 
+    logthis("?2");
 	return "";
 }
 
@@ -114,8 +134,11 @@ function createPageIfNotExisting( array $rawParams ) {
 function doCreatePages( &$article, &$editInfo, $changed ) {
 	global $egAutoCreatePageMaxRecursion;
 
-	$createPageData = $editInfo->output->getExtensionData( 'createPage' );
-	if ( is_null( $createPageData ) ) {
+    logthis("doCreatePages is run!");
+    
+    $createPageData = $editInfo->output->getExtensionData( 'createPage' );
+    if ( is_null( $createPageData ) ) {
+        logthis("No Pages to create!");
 		return true; // no pages to create
 	}
 

--- a/AutoCreatePage.php
+++ b/AutoCreatePage.php
@@ -25,6 +25,7 @@
 print "Hello World :)";
 if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'Not an entry point.' );
+	print "Hello World :(";
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ from your extension directory. Then add to your LocalSettings.php:
 
 `include_once "$IP/extensions/AutoCreatePage/AutoCreatePage.php";`
 
-Also change to your wikiurl and add 
+Also **change to your wikiurl** and add 
 
 ```
 $egAutoCreatePageLogfile="autocreatepage.log";

--- a/README.md
+++ b/README.md
@@ -54,8 +54,15 @@ from your extension directory. Then add to your LocalSettings.php:
 
 `include_once "$IP/extensions/AutoCreatePage/AutoCreatePage.php";`
 
-The code requires MediaWiki 1.21 to work. It has been tested on MediaWiki 1.23.
-Future versions might also work.
+Also change to your wikiurl and add 
+
+```
+$egAutoCreatePageLogfile="autocreatepage.log";
+$egAutoCreatePageAPIEndpoint="$YOURWIKIURL/api.php";
+```
+`to the Localsettings.php
+
+Tested in mediawiki 1.39. Should work in most earlier versions.
 
 
 Configuration
@@ -83,10 +90,6 @@ Status
 ------
 
 This code is experimental. Use with care. Internationalization is largely missing.
-
-As of MediaWiki 1.23, the code avoids deprecated functions or hooks. However, it
-accesses the parser's `mStripState` member (intended private?) to process nowiki
-tags. This might have to be replaced by some other approach in the future.
 
 
 Credits

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Also **change to your wikiurl** and add
 $egAutoCreatePageLogfile="autocreatepage.log";
 $egAutoCreatePageAPIEndpoint="$YOURWIKIURL/api.php";
 ```
-`to the Localsettings.php
+to the Localsettings.php
 
 Tested in mediawiki 1.39. Should work in most earlier versions.
 


### PR DESCRIPTION
I replaced depreciated hooks with new ones and the page edit is now done via the api and the php-curl module. 

For API usage, I needed to add a variable to be set in Localsettings.php but set a sane default value.

Also the extension can now write to a logfile, also definable in the Localsettings.php

Still TODO:
* get mediawiki api url from code without user input
* test recursion stop
* add reasonable error handling