### PR TITLE
Modernise for 1.39

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: "1.35"
-            experimental: false
-          - mediawiki_version: "1.36"
-            experimental: false
-          - mediawiki_version: "1.37"
-            experimental: false
           - mediawiki_version: "1.39"
             experimental: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,27 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
-
   ci:
-
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
+          - mediawiki_version: "1.35"
             experimental: false
-          - mediawiki_version: '1.36'
-            experimental: true
-          - mediawiki_version: '1.37'
-            experimental: true
+          - mediawiki_version: "1.36"
+            experimental: false
+          - mediawiki_version: "1.37"
+            experimental: false
+          - mediawiki_version: "1.39"
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ MW_VERSION ?= 1.35
 EXTENSION_FOLDER := /var/www/html/extensions/$(EXTENSION)
 IMAGE_NAME := $(shell echo $(EXTENSION) | tr A-Z a-z}):test-$(MW_VERSION)
 PWD := $(shell bash -c "pwd -W 2>/dev/null || pwd")# this way it works on Windows and Linux
+DOCKER ?= docker
 DOCKER_RUN_ARGS := --rm -v $(PWD)/coverage:$(EXTENSION_FOLDER)/coverage -w $(EXTENSION_FOLDER) $(IMAGE_NAME)
-docker_run := docker run $(DOCKER_RUN_ARGS)
+docker_run := $(DOCKER) run $(DOCKER_RUN_ARGS)
 
 .PHONY: all
 all:
@@ -21,7 +22,7 @@ ci-coverage: build test-coverage
 
 .PHONY: build
 build:
-	docker build --tag $(IMAGE_NAME) \
+	$(DOCKER) build --tag $(IMAGE_NAME) \
 		--build-arg=MW_VERSION=$(MW_VERSION) \
 		.
 
@@ -41,11 +42,11 @@ composer-test-coverage:
 
 .PHONY: bash
 bash:
-	docker run -it -v $(PWD):/src $(DOCKER_RUN_ARGS) bash
+	$(docker) run -it -v $(PWD):/src $(DOCKER_RUN_ARGS) bash
 
 .PHONY: dev-bash
 dev-bash:
-	docker run -it --rm -p 8080:8080 \
+	$(docker) run -it --rm -p 8080:8080 \
 		-v $(PWD):$(EXTENSION_FOLDER) \
 		-v $(EXTENSION_FOLDER)/vendor/  \
 		-w $(EXTENSION_FOLDER) $(IMAGE_NAME) bash -c 'service apache2 start && bash'

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ directory of your MediaWiki installation. You can do this with git by calling:
 
 from your extension directory. Then add to your LocalSettings.php:
 
-`include_once "$IP/extensions/AutoCreatePage/AutoCreatePage.php";`
+`mfLoadExtension( 'AutoCreatePage' );`
 
-The code requires MediaWiki 1.21 to work. It has been tested on MediaWiki 1.23.
+The code requires MediaWiki 1.39 to work. It has been tested on MediaWiki 1.39.
 Future versions might also work.
 
 
@@ -84,9 +84,7 @@ Status
 
 This code is experimental. Use with care. Internationalization is largely missing.
 
-As of MediaWiki 1.23, the code avoids deprecated functions or hooks. However, it
-accesses the parser's `mStripState` member (intended private?) to process nowiki
-tags. This might have to be replaced by some other approach in the future.
+As of MediaWiki 1.39, the code avoids deprecated functions or hooks.
 
 
 Credits

--- a/src/AutoCreatePage.php
+++ b/src/AutoCreatePage.php
@@ -2,14 +2,16 @@
 
 namespace ACP;
 
-use ContentHandler;
+use CommentStoreComment;
 use MediaWiki\Hook\ParserFirstCallInitHook;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\SlotRecord;
 use MediaWiki\SpecialPage\Hook\SpecialPageAfterExecuteHook;
 use MediaWiki\SpecialPage\Hook\SpecialPageBeforeExecuteHook;
 use MediaWiki\Storage\Hook\RevisionDataUpdatesHook;
 use Parser;
 use Title;
-use WikiPage;
+use WikitextContent;
 
 /**
  * This extension provides a parser function #createpageifnotex that can be used to create
@@ -77,11 +79,15 @@ class AutoCreatePage implements
 
 		// Get the raw text of $newPageContent as it was before stripping <nowiki>:
 		$newPageContent = $parser->getStripState()->unstripNoWiki( $newPageContent );
+		$newPageData = [
+			"content" => $newPageContent,
+			"user" => $parser->getUserIdentity()
+		];
 
 		$enabledSpecialPage = self::enabledSpecialPage();
 		if ( $enabledSpecialPage ) {
 			// Store data in static variable for later use in onSpecialPageAfterExecute:
-			$enabledSpecialPage->addPageToCreate( $newPageTitleText, $newPageContent );
+			$enabledSpecialPage->addPageToCreate( $newPageTitleText, $newPageData );
 		} elseif ( in_array( $parser->getTitle()->getNamespace(), $autoCreatePageNamespaces ) ) {
 			// For pages with namespace in $autoCreatePageNamespaces store data in the parser output
 			// for later use in onRevisionDataUpdates:s
@@ -89,7 +95,7 @@ class AutoCreatePage implements
 			if ( $createPageData === null ) {
 				$createPageData = [];
 			}
-			$createPageData[$newPageTitleText] = $newPageContent;
+			$createPageData[$newPageTitleText] = $newPageData;
 			$parser->getOutput()->setExtensionData( 'createPage', $createPageData );
 		}
 
@@ -114,8 +120,8 @@ class AutoCreatePage implements
 		// Prevent pages to be created by pages that are created to avoid loops:
 		$egAutoCreatePageMaxRecursion--;
 
-		foreach ( $createPageData as $pageTitleText => $pageContentText ) {
-			self::createPage( $title, $pageTitleText, $pageContentText );
+		foreach ( $createPageData as $pageTitleText => $pageContentData ) {
+			self::createPage( $title, $pageTitleText, $pageContentData );
 		}
 
 		// Reset state. Probably not needed since parsing is usually done here anyway:
@@ -142,8 +148,8 @@ class AutoCreatePage implements
 		$specialPage = array_pop( self::$specialPageStack );
 
 		if ( $specialPage->isEnabled() ) {
-			foreach ( $specialPage->pagesToCreate() as $pageTitleText => $pageContentText ) {
-				self::createPage( $special->getFullTitle(), $pageTitleText, $pageContentText );
+			foreach ( $specialPage->pagesToCreate() as $pageTitleText => $pageContentData ) {
+				self::createPage( $special->getFullTitle(), $pageTitleText, $pageContentData );
 			}
 		}
 	}
@@ -157,16 +163,23 @@ class AutoCreatePage implements
 		return $currentSpecialPage !== null && $currentSpecialPage->isEnabled() ? $currentSpecialPage : null;
 	}
 
-	private static function createPage( $sourceTitle, $pageTitleText, $pageContentText ) {
+	private static function createPage( $sourceTitle, $pageTitleText, $pageContentData ) {
+		$pageContentText = new WikitextContent( $pageContentData["content"] );
+		$author = $pageContentData["user"];
 		$sourceTitleText = $sourceTitle->getPrefixedText();
 		$pageTitle = Title::newFromText( $pageTitleText );
 		// wfDebugLog( 'createpage', "CREATE " . $pageTitle->getText() . " Text: " . $pageContent );
 
 		if ( $pageTitle !== null && !$pageTitle->isKnown() && $pageTitle->canExist() ) {
-			$newWikiPage = new WikiPage( $pageTitle );
-			$pageContent = ContentHandler::makeContent( $pageContentText, $sourceTitle );
-			$newWikiPage->doEditContent( $pageContent,
-				"Page created automatically by parser function on page [[$sourceTitleText]]" ); // TODO i18n
+			$page = $pageTitle->toPageIdentity();
+			$comment = CommentStoreComment::newUnsavedComment(
+				"Page created automatically by parser function on page [[$sourceTitleText]]" // TODO i18n
+			);
+			$factory = MediaWikiServices::getInstance()->getPageUpdaterFactory();
+			$updater = $factory->newPageUpdater( $page, $author );
+			$updater->setContent( SlotRecord::MAIN, $pageContentText );
+			$updater->saveRevision( $comment );
+
 			// wfDebugLog( 'createpage', "CREATED PAGE " . $pageTitle->getText() . " Text: " . $pageContent );
 		}
 	}

--- a/src/AutoCreatePage.php
+++ b/src/AutoCreatePage.php
@@ -126,7 +126,6 @@ class AutoCreatePage implements
 
 		// Reset state. Probably not needed since parsing is usually done here anyway:
 		$output->setExtensionData( 'createPage', null );
-		$egAutoCreatePageMaxRecursion++;
 
 		return true;
 	}

--- a/src/SpecialPage.php
+++ b/src/SpecialPage.php
@@ -15,8 +15,8 @@ class SpecialPage {
 		return $this->isEnabled;
 	}
 
-	public function addPageToCreate( $titleText, $content ) {
-		$this->pagesToCreate[$titleText] = $content;
+	public function addPageToCreate( $titleText, $data ) {
+		$this->pagesToCreate[$titleText] = $data;
 	}
 
 	public function pagesToCreate() {


### PR DESCRIPTION
This avoids APIs removed in 1.39. Unfortunately, that also breaks compatibility with 1.37, so use older versions if you need that.